### PR TITLE
Include GitHub repository in the package.json 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "license": "ISC",
   "type": "module",
   "main": "src/client.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mistralai/client-js"
+  },
   "dependencies": {
     "axios": "^1.6.2",
     "axios-retry": "^4.0.0"


### PR DESCRIPTION
So users on npm can find the Javascript client open source GitHub repo through npmjs.org.

I had to go digging to find this repo since it wasn't linked on npm.

Cheers!