### PR TITLE
docs: add usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,63 @@ You can install the library in your project using:
 
 `npm install @mistralai/mistralai`
 
+## Usage
+### Set up
+```typescript
+import MistralClient from '@mistralai/mistralai';
+
+const apiKey = "Your API key";
+
+const client = new MistralClient(apiKey);
+```
+
+### List models
+```typescript
+const listModelsResponse = await client.listModels();
+const listModels = listModelsResponse.data;
+listModels.forEach((model) => {
+  console.log('Model:', model);
+});
+```
+
+### Chat with streaming
+```typescript
+const chatStreamResponse = await client.chatStream({
+  model: 'mistral-tiny',
+  messages: [{role: 'user', content: 'What is the best French cheese?'}],
+});
+
+console.log('Chat Stream:');
+for await (const chunk of chatStreamResponse) {
+  if (chunk.choices[0].delta.content !== undefined) {
+    const streamText = chunk.choices[0].delta.content;
+    process.stdout.write(streamText);
+  }
+}
+```
+### Chat without streaming
+```typescript
+const chatResponse = await client.chat({
+  model: 'mistral-tiny',
+  messages: [{role: 'user', content: 'What is the best French cheese?'}],
+});
+
+console.log('Chat:', chatResponse.choices[0].message.content);
+```
+###Embeddings
+```typescript
+const input = [];
+for (let i = 0; i < 1; i++) {
+  input.push('What is the best French cheese?');
+}
+
+const embeddingsBatchResponse = await client.embeddings({
+  model: 'mistral-embed',
+  input: input,
+});
+
+console.log('Embeddings Batch:', embeddingsBatchResponse.data);
+```
 ## Run examples
 
 You can run the examples in the examples directory by installing them locally:


### PR DESCRIPTION
I think is an easier way to visualize how to use the library instead of having to enter in the examples folder.