### PR TITLE
Adds extended types for client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "ISC",
   "type": "module",
   "main": "src/client.js",
+  "types": "src/mistralai.d.ts",
   "dependencies": {
     "axios": "^1.6.2",
     "axios-retry": "^4.0.0"

--- a/src/mistralai.d.ts
+++ b/src/mistralai.d.ts
@@ -1,0 +1,136 @@
+declare module '@mistralai/mistralai' {
+    export interface ModelPermission {
+        id: string;
+        object: 'model_permission';
+        created: number;
+        allow_create_engine: boolean;
+        allow_sampling: boolean;
+        allow_logprobs: boolean;
+        allow_search_indices: boolean;
+        allow_view: boolean;
+        allow_fine_tuning: boolean;
+        organization: string;
+        group: string | null;
+        is_blocking: boolean;
+    }
+
+    export interface Model {
+        id: string;
+        object: 'model';
+        created: number;
+        owned_by: string;
+        root: string | null;
+        parent: string | null;
+        permission: ModelPermission[];
+    }
+
+    export interface ListModelsResponse {
+        object: 'list';
+        data: Model[];
+    }
+
+    export interface TokenUsage {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+    }
+
+    export interface ChatCompletionResponseChoice {
+        index: number;
+        message: {
+            role: string;
+            content: string;
+        };
+        finish_reason: string;
+    }
+
+    export interface ChatCompletionResponseChunkChoice {
+        index: number;
+        delta: {
+            role?: string;
+            content?: string;
+        };
+        finish_reason: string;
+    }
+
+    export interface ChatCompletionResponse {
+        id: string;
+        object: 'chat.completion';
+        created: number;
+        model: string;
+        choices: ChatCompletionResponseChoice[];
+        usage: TokenUsage;
+    }
+
+    export interface ChatCompletionResponseChunk {
+        id: string;
+        object: 'chat.completion.chunk';
+        created: number;
+        model: string;
+        choices: ChatCompletionResponseChunkChoice[];
+    }
+
+    export interface Embedding {
+        id: string;
+        object: 'embedding';
+        embedding: number[];
+    }
+
+    export interface EmbeddingResponse {
+        id: string;
+        object: 'list';
+        data: Embedding[];
+        model: string;
+        usage: TokenUsage;
+    }
+
+    class MistralClient {
+        constructor(apiKey?: string, endpoint?: string);
+
+        private _request(
+            method: string,
+            path: string,
+            request: unknown
+        ): Promise<unknown>;
+
+        private _makeChatCompletionRequest(
+            model: string,
+            messages: Array<{ role: string; content: string }>,
+            temperature?: number,
+            maxTokens?: number,
+            topP?: number,
+            randomSeed?: number,
+            stream?: boolean,
+            safeMode?: boolean
+        ): object;
+
+        listModels(): Promise<ListModelsResponse>;
+
+        chat(options: {
+            model: string;
+            messages: Array<{ role: string; content: string }>;
+            temperature?: number;
+            maxTokens?: number;
+            topP?: number;
+            randomSeed?: number;
+            safeMode?: boolean;
+        }): Promise<ChatCompletionResponse>;
+
+        chatStream(options: {
+            model: string;
+            messages: Array<{ role: string; content: string }>;
+            temperature?: number;
+            maxTokens?: number;
+            topP?: number;
+            randomSeed?: number;
+            safeMode?: boolean;
+        }): AsyncGenerator<ChatCompletionResponseChunk, void, unknown>;
+
+        embeddings(options: {
+            model: string;
+            input: string | string[];
+        }): Promise<EmbeddingResponse>;
+    }
+
+    export default MistralClient;
+}


### PR DESCRIPTION
This PR adds extended TypeScript type definitions for the client.js code, fixing #3. This is based on work by @sublimator and @oliviermills and probably should replace #10. 