### PR TITLE
Add tool_calls in the signature of chat response

### DIFF
--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -76,6 +76,7 @@ declare module '@mistralai/mistralai' {
         message: {
             role: string;
             content: string;
+            tool_calls: null | ToolCalls[];
         };
         finish_reason: string;
     }
@@ -133,7 +134,7 @@ declare module '@mistralai/mistralai' {
         private _makeChatCompletionRequest(
             model: string,
             messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>,
-            tools?: Array<{ type: string; function:Function; }>, 
+            tools?: Array<{ type: string; function: Function; }>,
             temperature?: number,
             maxTokens?: number,
             topP?: number,
@@ -153,7 +154,7 @@ declare module '@mistralai/mistralai' {
         chat(options: {
             model: string;
             messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>;
-            tools?: Array<{ type: string; function:Function; }>; 
+            tools?: Array<{ type: string; function: Function; }>;
             temperature?: number;
             maxTokens?: number;
             topP?: number;
@@ -164,13 +165,13 @@ declare module '@mistralai/mistralai' {
             safeMode?: boolean;
             safePrompt?: boolean;
             toolChoice?: ToolChoice;
-            responseFormat?: ResponseFormat; 
+            responseFormat?: ResponseFormat;
         }): Promise<ChatCompletionResponse>;
 
         chatStream(options: {
             model: string;
             messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>;
-            tools?: Array<{ type: string; function:Function; }>;
+            tools?: Array<{ type: string; function: Function; }>;
             temperature?: number;
             maxTokens?: number;
             topP?: number;


### PR DESCRIPTION
The current signature of `ChatCompletionResponseChoice` is incorrect since it doesn't add the `tool_calls`. 
Actually, the response can be either `null` or the `ToolCalls[]` as shown in this screenshot (this is a console.log of the message)

![CleanShot 2024-03-04 at 15 59 12@2x](https://github.com/mistralai/client-js/assets/235510/3dfcb1a4-d6d5-420d-8b6e-a0ac455b95fe)

