### PR TITLE
Fix capitalization and add partner course

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-This javascript client is inspired from [cohere-typescript](https://github.com/cohere-ai/cohere-typescript)
+This JavaScript client is inspired from [cohere-typescript](https://github.com/cohere-ai/cohere-typescript)
 
-# Mistral Javascript Client
+# Mistral JavaScript Client
 
-You can use the Mistral Javascript client to interact with the Mistral AI API.
+You can use the Mistral JavaScript client to interact with the Mistral AI API.
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ You can install the library in your project using:
 
 ## Usage
 
+You can watch a free course on using the Mistral JavaScript client [here.](https://scrimba.com/links/mistral)
+
 ### Set up
 
 ```typescript


### PR DESCRIPTION
Hi,

as a part of the [partnership between Scrimba and Mistral](https://scrimba.com/articles/mistral-scrimba-partnership/), we have recorded a free intro course on the Mistral JavaScript client. Adding a link to it here as it'll help new developers to onboard to your API and platform more easily.

I've also fixed the capitalization of "JavaScript" in the README.