### PR TITLE
Don't override global fetch & fix tests

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -9,17 +9,19 @@ const ENDPOINT = 'https://api.mistral.ai';
  * @return {Promise<void>}
  */
 async function initializeFetch() {
-  if (typeof window === 'undefined' ||
-    typeof globalThis.fetch === 'undefined') {
-    const nodeFetch = await import('node-fetch');
-    fetch = nodeFetch.default;
+  if (typeof window === 'undefined') {
     isNode = true;
+  }
+
+  if (typeof globalThis.fetch === 'undefined') {
+    const nodeFetch = await import('node-fetch');
+    globalThis.mistralFetch = nodeFetch.default;
   } else {
-    fetch = globalThis.fetch;
+    globalThis.mistralFetch = globalThis.fetch;
   }
 }
 
-initializeFetch();
+await initializeFetch();
 
 /**
  * MistralAPIError
@@ -90,7 +92,7 @@ class MistralClient {
 
     for (let attempts = 0; attempts < this.maxRetries; attempts++) {
       try {
-        const response = await fetch(url, options);
+        const response = await globalThis.mistralFetch(url, options);
 
         if (response.ok) {
           if (request?.stream) {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -20,7 +20,7 @@ describe('Mistral Client', () => {
     it('should return a chat response object', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      globalThis.mistralFetch = mockFetch(200, mockResponse);
 
       const response = await client.chat({
         model: 'mistral-small',
@@ -37,7 +37,7 @@ describe('Mistral Client', () => {
     it('should return a chat response object if safeMode is set', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      globalThis.mistralFetch = mockFetch(200, mockResponse);
 
       const response = await client.chat({
         model: 'mistral-small',
@@ -55,7 +55,7 @@ describe('Mistral Client', () => {
     it('should return a chat response object if safePrompt is set', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      globalThis.mistralFetch = mockFetch(200, mockResponse);
 
       const response = await client.chat({
         model: 'mistral-small',
@@ -75,7 +75,7 @@ describe('Mistral Client', () => {
     it('should return parsed, streamed response', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponseStreamingPayload();
-      globalThis.fetch = mockFetchStream(200, mockResponse);
+      globalThis.mistralFetch = mockFetchStream(200, mockResponse);
 
       const response = await client.chatStream({
         model: 'mistral-small',
@@ -98,7 +98,7 @@ describe('Mistral Client', () => {
     it('should return parsed, streamed response with safeMode', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponseStreamingPayload();
-      globalThis.fetch = mockFetchStream(200, mockResponse);
+      globalThis.mistralFetch = mockFetchStream(200, mockResponse);
 
       const response = await client.chatStream({
         model: 'mistral-small',
@@ -122,7 +122,7 @@ describe('Mistral Client', () => {
     it('should return parsed, streamed response with safePrompt', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponseStreamingPayload();
-      globalThis.fetch = mockFetchStream(200, mockResponse);
+      globalThis.mistralFetch = mockFetchStream(200, mockResponse);
 
       const response = await client.chatStream({
         model: 'mistral-small',
@@ -148,7 +148,7 @@ describe('Mistral Client', () => {
     it('should return embeddings', async() => {
       // Mock the fetch function
       const mockResponse = mockEmbeddingResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      globalThis.mistralFetch = mockFetch(200, mockResponse);
 
       const response = await client.embeddings(mockEmbeddingRequest);
       expect(response).toEqual(mockResponse);
@@ -159,7 +159,7 @@ describe('Mistral Client', () => {
     it('should return batched embeddings', async() => {
       // Mock the fetch function
       const mockResponse = mockEmbeddingResponsePayload(10);
-      globalThis.fetch = mockFetch(200, mockResponse);
+      globalThis.mistralFetch = mockFetch(200, mockResponse);
 
       const response = await client.embeddings(mockEmbeddingRequest);
       expect(response).toEqual(mockResponse);
@@ -170,7 +170,7 @@ describe('Mistral Client', () => {
     it('should return a list of models', async() => {
       // Mock the fetch function
       const mockResponse = mockListModels();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      globalThis.mistralFetch = mockFetch(200, mockResponse);
 
       const response = await client.listModels();
       expect(response).toEqual(mockResponse);


### PR DESCRIPTION
Use globalThis.mistralFetch instead of globalThis.fetch to avoid overriding it.
Fix isNode logic.

Thanks [@flakey5](https://github.com/flakey5) for the contribution.