### PR TITLE
feat: update fetch configuration logic

### DIFF
--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -20,7 +20,7 @@ describe('Mistral Client', () => {
     it('should return a chat response object', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      client._fetch = mockFetch(200, mockResponse);
 
       const response = await client.chat({
         model: 'mistral-small',
@@ -37,7 +37,7 @@ describe('Mistral Client', () => {
     it('should return a chat response object if safeMode is set', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      client._fetch = mockFetch(200, mockResponse);
 
       const response = await client.chat({
         model: 'mistral-small',
@@ -55,7 +55,7 @@ describe('Mistral Client', () => {
     it('should return a chat response object if safePrompt is set', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      client._fetch = mockFetch(200, mockResponse);
 
       const response = await client.chat({
         model: 'mistral-small',
@@ -75,7 +75,7 @@ describe('Mistral Client', () => {
     it('should return parsed, streamed response', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponseStreamingPayload();
-      globalThis.fetch = mockFetchStream(200, mockResponse);
+      client._fetch = mockFetchStream(200, mockResponse);
 
       const response = await client.chatStream({
         model: 'mistral-small',
@@ -98,7 +98,7 @@ describe('Mistral Client', () => {
     it('should return parsed, streamed response with safeMode', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponseStreamingPayload();
-      globalThis.fetch = mockFetchStream(200, mockResponse);
+      client._fetch = mockFetchStream(200, mockResponse);
 
       const response = await client.chatStream({
         model: 'mistral-small',
@@ -122,7 +122,7 @@ describe('Mistral Client', () => {
     it('should return parsed, streamed response with safePrompt', async() => {
       // Mock the fetch function
       const mockResponse = mockChatResponseStreamingPayload();
-      globalThis.fetch = mockFetchStream(200, mockResponse);
+      client._fetch = mockFetchStream(200, mockResponse);
 
       const response = await client.chatStream({
         model: 'mistral-small',
@@ -148,7 +148,7 @@ describe('Mistral Client', () => {
     it('should return embeddings', async() => {
       // Mock the fetch function
       const mockResponse = mockEmbeddingResponsePayload();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      client._fetch = mockFetch(200, mockResponse);
 
       const response = await client.embeddings(mockEmbeddingRequest);
       expect(response).toEqual(mockResponse);
@@ -159,7 +159,7 @@ describe('Mistral Client', () => {
     it('should return batched embeddings', async() => {
       // Mock the fetch function
       const mockResponse = mockEmbeddingResponsePayload(10);
-      globalThis.fetch = mockFetch(200, mockResponse);
+      client._fetch = mockFetch(200, mockResponse);
 
       const response = await client.embeddings(mockEmbeddingRequest);
       expect(response).toEqual(mockResponse);
@@ -170,7 +170,7 @@ describe('Mistral Client', () => {
     it('should return a list of models', async() => {
       // Mock the fetch function
       const mockResponse = mockListModels();
-      globalThis.fetch = mockFetch(200, mockResponse);
+      client._fetch = mockFetch(200, mockResponse);
 
       const response = await client.listModels();
       expect(response).toEqual(mockResponse);


### PR DESCRIPTION
Squashed version of #65 which was an exploration branch for a new version, including non-relevant commits

Closes:
* Closes #42 
* Closes #60
* Closes #63
* Closes #44  

Update fetch detection logic (See: https://github.com/mistralai/client-js/pull/63#discussion_r1582538661):
* Add client._fetch hook point for tests rather than using a global
* ~~Use top level await, per [here](https://github.com/mistralai/client-js/pull/60/files#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0R24) and [here](https://github.com/mistralai/client-js/pull/63/files#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0R24) (this won't work in commonjs)~~
* Use native fetch when available on node 
* Support service workers such as manifest version 3 Web Extensions