### PR TITLE
feat: add signal support and fix timeout, closes #5

### DIFF
--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -3,7 +3,7 @@ name: Build and Publish
 on:
   push:
     branches: ["main"]
-    
+
     # We only deploy on tags and main branch
     tags:
       # Only run on tags that match the following regex
@@ -14,13 +14,13 @@ on:
   pull_request:
 
 jobs:
-  
+
   lint_and_test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [18, 20]
+        node-version: [18, 20, 22]
 
     steps:
       # Checkout the repository
@@ -72,4 +72,3 @@ jobs:
           sed -i 's/VERSION = '\''0.0.1'\''/VERSION = '\''${{ github.ref_name }}'\''/g' src/client.js
           npm publish 
 
-      

--- a/src/client.js
+++ b/src/client.js
@@ -69,9 +69,10 @@ class MistralClient {
    * @param {*} method
    * @param {*} path
    * @param {*} request
+   * @param {*} signal
    * @return {Promise<*>}
    */
-  _request = async function(method, path, request) {
+  _request = async function(method, path, request, signal) {
     const url = `${this.endpoint}/${path}`;
     const options = {
       method: method,
@@ -82,7 +83,7 @@ class MistralClient {
         'Authorization': `Bearer ${this.apiKey}`,
       },
       body: method !== 'get' ? JSON.stringify(request) : null,
-      timeout: this.timeout * 1000,
+      signal: signal ?? AbortSignal.timeout(this.timeout * 1000),
     };
 
     for (let attempts = 0; attempts < this.maxRetries; attempts++) {
@@ -221,6 +222,8 @@ class MistralClient {
    * @param {*} safePrompt whether to use safe mode, e.g. true
    * @param {*} toolChoice the tool to use, e.g. 'auto'
    * @param {*} responseFormat the format of the response, e.g. 'json_format'
+   * @param {*} [signal=AbortSignal.timeout(...)] -
+   *        An optional AbortSignal instance to control the operation.
    * @return {Promise<Object>}
    */
   chat = async function({
@@ -233,6 +236,7 @@ class MistralClient {
     randomSeed,
     safeMode,
     safePrompt,
+    signal,
     toolChoice,
     responseFormat,
   }) {
@@ -254,6 +258,7 @@ class MistralClient {
       'post',
       'v1/chat/completions',
       request,
+      signal,
     );
     return response;
   };
@@ -272,6 +277,8 @@ class MistralClient {
    * @param {*} safePrompt whether to use safe mode, e.g. true
    * @param {*} toolChoice the tool to use, e.g. 'auto'
    * @param {*} responseFormat the format of the response, e.g. 'json_format'
+   * @param {*} [signal=AbortSignal.timeout(...)] -
+   *        An optional AbortSignal instance to control the operation.
    * @return {Promise<Object>}
    */
   chatStream = async function* ({
@@ -284,6 +291,7 @@ class MistralClient {
     randomSeed,
     safeMode,
     safePrompt,
+    signal,
     toolChoice,
     responseFormat,
   }) {
@@ -305,6 +313,7 @@ class MistralClient {
       'post',
       'v1/chat/completions',
       request,
+      signal,
     );
 
     let buffer = '';

--- a/src/client.js
+++ b/src/client.js
@@ -233,21 +233,30 @@ class MistralClient {
   };
 
   /**
-   * A chat endpoint without streaming
-   * @param {*} model the name of the model to chat with, e.g. mistral-tiny
-   * @param {*} messages an array of messages to chat with, e.g.
-   * [{role: 'user', content: 'What is the best French cheese?'}]
-   * @param {*} tools  a list of tools to use.
-   * @param {*} temperature the temperature to use for sampling, e.g. 0.5
-   * @param {*} maxTokens the maximum number of tokens to generate, e.g. 100
-   * @param {*} topP the cumulative probability of tokens to generate, e.g. 0.9
-   * @param {*} randomSeed the random seed to use for sampling, e.g. 42
-   * @param {*} safeMode deprecated use safePrompt instead
-   * @param {*} safePrompt whether to use safe mode, e.g. true
-   * @param {*} toolChoice the tool to use, e.g. 'auto'
-   * @param {*} responseFormat the format of the response, e.g. 'json_format'
-   * @param {*} [signal] - optional AbortSignal instance to control request
-   *            The signal will be combined with default timeout signal
+   * A chat endpoint without streaming.
+   *
+   * @param {Object} data - The main chat configuration.
+   * @param {*} data.model - the name of the model to chat with,
+   *                         e.g. mistral-tiny
+   * @param {*} data.messages - an array of messages to chat with, e.g.
+   *                            [{role: 'user', content: 'What is the best
+   *                            French cheese?'}]
+   * @param {*} data.tools - a list of tools to use.
+   * @param {*} data.temperature - the temperature to use for sampling, e.g. 0.5
+   * @param {*} data.maxTokens - the maximum number of tokens to generate,
+   *                             e.g. 100
+   * @param {*} data.topP - the cumulative probability of tokens to generate,
+   *                        e.g. 0.9
+   * @param {*} data.randomSeed - the random seed to use for sampling, e.g. 42
+   * @param {*} data.safeMode - deprecated use safePrompt instead
+   * @param {*} data.safePrompt - whether to use safe mode, e.g. true
+   * @param {*} data.toolChoice - the tool to use, e.g. 'auto'
+   * @param {*} data.responseFormat - the format of the response,
+   *                                  e.g. 'json_format'
+   * @param {Object} options - Additional operational options.
+   * @param {*} [options.signal] - optional AbortSignal instance to control
+   *                               request The signal will be combined with
+   *                               default timeout signal
    * @return {Promise<Object>}
    */
   chat = async function({
@@ -260,10 +269,9 @@ class MistralClient {
     randomSeed,
     safeMode,
     safePrompt,
-    signal,
     toolChoice,
     responseFormat,
-  }) {
+  }, {signal}) {
     const request = this._makeChatCompletionRequest(
       model,
       messages,
@@ -289,20 +297,29 @@ class MistralClient {
 
   /**
    * A chat endpoint that streams responses.
-   * @param {*} model the name of the model to chat with, e.g. mistral-tiny
-   * @param {*} messages an array of messages to chat with, e.g.
-   * [{role: 'user', content: 'What is the best French cheese?'}]
-   * @param {*} tools  a list of tools to use.
-   * @param {*} temperature the temperature to use for sampling, e.g. 0.5
-   * @param {*} maxTokens the maximum number of tokens to generate, e.g. 100
-   * @param {*} topP the cumulative probability of tokens to generate, e.g. 0.9
-   * @param {*} randomSeed the random seed to use for sampling, e.g. 42
-   * @param {*} safeMode deprecated use safePrompt instead
-   * @param {*} safePrompt whether to use safe mode, e.g. true
-   * @param {*} toolChoice the tool to use, e.g. 'auto'
-   * @param {*} responseFormat the format of the response, e.g. 'json_format'
-   * @param {*} [signal] - optional AbortSignal instance to control request
-   *            The signal will be combined with default timeout signal
+   *
+   * @param {Object} data - The main chat configuration.
+   * @param {*} data.model - the name of the model to chat with,
+   *                         e.g. mistral-tiny
+   * @param {*} data.messages - an array of messages to chat with, e.g.
+   *                            [{role: 'user', content: 'What is the best
+   *                            French cheese?'}]
+   * @param {*} data.tools - a list of tools to use.
+   * @param {*} data.temperature - the temperature to use for sampling, e.g. 0.5
+   * @param {*} data.maxTokens - the maximum number of tokens to generate,
+   *                             e.g. 100
+   * @param {*} data.topP - the cumulative probability of tokens to generate,
+   *                        e.g. 0.9
+   * @param {*} data.randomSeed - the random seed to use for sampling, e.g. 42
+   * @param {*} data.safeMode - deprecated use safePrompt instead
+   * @param {*} data.safePrompt - whether to use safe mode, e.g. true
+   * @param {*} data.toolChoice - the tool to use, e.g. 'auto'
+   * @param {*} data.responseFormat - the format of the response,
+   *                                  e.g. 'json_format'
+   * @param {Object} options - Additional operational options.
+   * @param {*} [options.signal] - optional AbortSignal instance to control
+   *                               request The signal will be combined with
+   *                               default timeout signal
    * @return {Promise<Object>}
    */
   chatStream = async function* ({
@@ -315,10 +332,9 @@ class MistralClient {
     randomSeed,
     safeMode,
     safePrompt,
-    signal,
     toolChoice,
     responseFormat,
-  }) {
+  }, {signal}) {
     const request = this._makeChatCompletionRequest(
       model,
       messages,

--- a/src/client.js
+++ b/src/client.js
@@ -271,7 +271,7 @@ class MistralClient {
     safePrompt,
     toolChoice,
     responseFormat,
-  }, {signal}) {
+  }, {signal} = {}) {
     const request = this._makeChatCompletionRequest(
       model,
       messages,
@@ -334,7 +334,7 @@ class MistralClient {
     safePrompt,
     toolChoice,
     responseFormat,
-  }, {signal}) {
+  }, {signal} = {}) {
     const request = this._makeChatCompletionRequest(
       model,
       messages,

--- a/src/client.js
+++ b/src/client.js
@@ -246,8 +246,8 @@ class MistralClient {
    * @param {*} safePrompt whether to use safe mode, e.g. true
    * @param {*} toolChoice the tool to use, e.g. 'auto'
    * @param {*} responseFormat the format of the response, e.g. 'json_format'
-   * @param {*} [signal=AbortSignal.timeout(...)] -
-   *        An optional AbortSignal instance to control the operation.
+   * @param {*} [signal] - optional AbortSignal instance to control request
+   *            The signal will be combined with default timeout signal
    * @return {Promise<Object>}
    */
   chat = async function({
@@ -301,8 +301,8 @@ class MistralClient {
    * @param {*} safePrompt whether to use safe mode, e.g. true
    * @param {*} toolChoice the tool to use, e.g. 'auto'
    * @param {*} responseFormat the format of the response, e.g. 'json_format'
-   * @param {*} [signal=AbortSignal.timeout(...)] -
-   *        An optional AbortSignal instance to control the operation.
+   * @param {*} [signal] - optional AbortSignal instance to control request
+   *            The signal will be combined with default timeout signal
    * @return {Promise<Object>}
    */
   chatStream = async function* ({


### PR DESCRIPTION
1. Added a new function `combineSignals` in `src/client.js` to merge AbortSignal instances.
1. Updated the `_request` method in `src/client.js` to accept an additional argument `signal` and use the `combineSignals` function to merge with a default timeout signal. 
1. Refactored the `chat` and `chatStream` methods in `src/client.js` to use a single object `data` for the main chat configuration and an additional options object `options`, where the signal is passed.
1. Updated the build and publish workflow to include Node.js version 22 in the matrix (closes #71 )
