### PR TITLE
fix: typescript definitions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,6 +4,7 @@ env:
 extends: google
 ignorePatterns:
   - examples/chat-react/
+  - src/client.d.ts
 parserOptions:
   ecmaVersion: latest
   sourceType: module

--- a/.github/workflows/build_publish.yaml
+++ b/.github/workflows/build_publish.yaml
@@ -48,6 +48,13 @@ jobs:
         run: |
           npm run test
 
+        # Build TypeScript Examples
+      - name: Build typescript examples
+        run: |
+          cd examples/typescript
+          npm install
+          npx tsc --build --verbose tsconfig.json
+
   publish:
     needs: lint_and_test
     runs-on: ubuntu-latest

--- a/examples/chat_with_streaming.js
+++ b/examples/chat_with_streaming.js
@@ -4,7 +4,7 @@ const apiKey = process.env.MISTRAL_API_KEY;
 
 const client = new MistralClient(apiKey);
 
-const chatStreamResponse = await client.chatStream({
+const chatStreamResponse = client.chatStream({
   model: 'mistral-tiny',
   messages: [{role: 'user', content: 'What is the best French cheese?'}],
 });

--- a/examples/typescript/chat_with_streaming.ts
+++ b/examples/typescript/chat_with_streaming.ts
@@ -1,0 +1,18 @@
+import MistralClient from '@mistralai/mistralai';
+
+const apiKey = process.env.MISTRAL_API_KEY;
+
+const client = new MistralClient(apiKey);
+
+const chatStreamResponse = await client.chatStream({
+  model: 'mistral-tiny',
+  messages: [{role: 'user', content: 'What is the best French cheese?'}],
+});
+
+console.log('Chat Stream:');
+for await (const chunk of chatStreamResponse) {
+  if (chunk.choices[0].delta.content !== undefined) {
+    const streamText = chunk.choices[0].delta.content;
+    process.stdout.write(streamText);
+  }
+}

--- a/examples/typescript/chat_with_streaming.ts
+++ b/examples/typescript/chat_with_streaming.ts
@@ -5,7 +5,7 @@ const apiKey = process.env.MISTRAL_API_KEY;
 const client = new MistralClient(apiKey);
 
 const responseInterface = '{"best": string, "reasoning": string}';
-const chatStreamResponse = await client.chatStream({
+const chatStreamResponse = client.chatStream({
   model: 'open-mistral-7b',
   responseFormat: {type: 'json_object'},
   messages: [{

--- a/examples/typescript/chat_with_streaming.ts
+++ b/examples/typescript/chat_with_streaming.ts
@@ -4,9 +4,15 @@ const apiKey = process.env.MISTRAL_API_KEY;
 
 const client = new MistralClient(apiKey);
 
+const responseInterface = '{"best": string, "reasoning": string}';
 const chatStreamResponse = await client.chatStream({
-  model: 'mistral-tiny',
-  messages: [{role: 'user', content: 'What is the best French cheese?'}],
+  model: 'open-mistral-7b',
+  responseFormat: {type: 'json_object'},
+  messages: [{
+    role: 'user', content: `
+    What is the best French cheese?
+    Answer in ${responseInterface} format`,
+  }],
 });
 
 console.log('Chat Stream:');

--- a/examples/typescript/package-lock.json
+++ b/examples/typescript/package-lock.json
@@ -1,0 +1,480 @@
+{
+  "name": "@mistralai/client-examples-ts",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@mistralai/client-examples-ts",
+      "dependencies": {
+        "@mistralai/mistralai": "file:../..",
+        "tsx": "^4.9.3"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.5"
+      }
+    },
+    "../..": {
+      "name": "@mistralai/mistralai",
+      "version": "0.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^2.6.7"
+      },
+      "devDependencies": {
+        "eslint": "^8.55.0",
+        "eslint-config-google": "^0.14.0",
+        "jest": "^29.7.0",
+        "prettier": "2.8.8"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.4.tgz",
+      "integrity": "sha512-ofbkKj+0pjXjhejr007J/fLf+sW+8H7K5GCm+msC8q3IpvgjobpyPqSRFemNyIMxklC0zeJpi7VDFna19FacvQ==",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.9.3.tgz",
+      "integrity": "sha512-czVbetlILiyJZI5zGlj2kw9vFiSeyra9liPD4nG+Thh4pKTi0AmMEQ8zdV/L2xbIVKrIqif4sUNrsMAOksx9Zg==",
+      "dependencies": {
+        "esbuild": "~0.20.2",
+        "get-tsconfig": "^4.7.3"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@mistralai/client-examples-ts",
+  "type": "module",
+  "dependencies": {
+    "@mistralai/mistralai": "file:../..",
+    "tsx": "^4.9.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -5,7 +5,6 @@
     "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true
+    "strict": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "ISC",
   "type": "module",
   "main": "src/client.js",
+  "types": "src/client.d.ts",
   "scripts": {
     "lint": "./node_modules/.bin/eslint .",
     "test": "node --experimental-vm-modules node_modules/.bin/jest"
@@ -17,7 +18,6 @@
     "type": "git",
     "url": "https://github.com/mistralai/client-js"
   },
-  "types": "src/client.d.ts",
   "dependencies": {
     "node-fetch": "^2.6.7"
   },

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -34,11 +34,6 @@ export interface Function {
   parameters: object;
 }
 
-// TODO: this is not actually used, but would technically be a break change to remove
-export enum ToolType {
-  function = 'function',
-}
-
 export interface FunctionCall {
   name: string;
   arguments: string;
@@ -47,16 +42,6 @@ export interface FunctionCall {
 export interface ToolCalls {
   id: string;
   function: FunctionCall;
-}
-
-export enum ResponseFormats {
-  json_object = 'json_object',
-}
-
-export enum ToolChoice {
-  auto = 'auto',
-  any = 'any',
-  none = 'none',
 }
 
 export interface ResponseFormat {
@@ -123,8 +108,6 @@ export interface EmbeddingResponse {
 
 export interface Message {
   role: string;
-  // TODO: this is not specified at https://docs.mistral.ai/redocusaurus/plugin-redoc-0.yaml
-  name?: string,
   content: string | string[]
 }
 

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -1,160 +1,162 @@
-export interface ModelPermission {
-  id: string;
-  object: 'model_permission';
-  created: number;
-  allow_create_engine: boolean;
-  allow_sampling: boolean;
-  allow_logprobs: boolean;
-  allow_search_indices: boolean;
-  allow_view: boolean;
-  allow_fine_tuning: boolean;
-  organization: string;
-  group: string | null;
-  is_blocking: boolean;
+declare module '@mistralai/mistralai' {
+    export interface ModelPermission {
+        id: string;
+        object: 'model_permission';
+        created: number;
+        allow_create_engine: boolean;
+        allow_sampling: boolean;
+        allow_logprobs: boolean;
+        allow_search_indices: boolean;
+        allow_view: boolean;
+        allow_fine_tuning: boolean;
+        organization: string;
+        group: string | null;
+        is_blocking: boolean;
+    }
+
+    export interface Model {
+        id: string;
+        object: 'model';
+        created: number;
+        owned_by: string;
+        root: string | null;
+        parent: string | null;
+        permission: ModelPermission[];
+    }
+
+    export interface ListModelsResponse {
+        object: 'list';
+        data: Model[];
+    }
+
+    export interface Function {
+        name: string;
+        description: string;
+        parameters: object;
+    }
+
+    export interface FunctionCall {
+        name: string;
+        arguments: string;
+    }
+
+    export interface ToolCalls {
+        id: string;
+        function: FunctionCall;
+    }
+
+    export interface ResponseFormat {
+        type: 'json_object';
+    }
+
+    export interface TokenUsage {
+        prompt_tokens: number;
+        completion_tokens: number;
+        total_tokens: number;
+    }
+
+    export interface ChatCompletionResponseChoice {
+        index: number;
+        message: {
+            role: string;
+            content: string;
+            tool_calls: null | ToolCalls[];
+        };
+        finish_reason: string;
+    }
+
+    export interface ChatCompletionResponseChunkChoice {
+        index: number;
+        delta: {
+            role?: string;
+            content?: string;
+            tool_calls?: ToolCalls[];
+        };
+        finish_reason: string;
+    }
+
+    export interface ChatCompletionResponse {
+        id: string;
+        object: 'chat.completion';
+        created: number;
+        model: string;
+        choices: ChatCompletionResponseChoice[];
+        usage: TokenUsage;
+    }
+
+    export interface ChatCompletionResponseChunk {
+        id: string;
+        object: 'chat.completion.chunk';
+        created: number;
+        model: string;
+        choices: ChatCompletionResponseChunkChoice[];
+        usage: TokenUsage | null;
+    }
+
+    export interface Embedding {
+        id: string;
+        object: 'embedding';
+        embedding: number[];
+    }
+
+    export interface EmbeddingResponse {
+        id: string;
+        object: 'list';
+        data: Embedding[];
+        model: string;
+        usage: TokenUsage;
+    }
+
+    export interface Message {
+        role: string;
+        content: string | string[]
+    }
+
+    export interface Tool {
+        type: 'function';
+        function: Function;
+    }
+
+    export interface ChatRequest {
+        model: string;
+        messages: Array<Message>;
+        tools?: Array<Tool>;
+        temperature?: number;
+        maxTokens?: number;
+        topP?: number;
+        randomSeed?: number;
+        /**
+         * @deprecated use safePrompt instead
+         */
+        safeMode?: boolean;
+        safePrompt?: boolean;
+        toolChoice?: 'auto' | 'any' | 'none';
+        responseFormat?: ResponseFormat;
+    }
+
+    export interface ChatRequestOptions {
+        signal?: AbortSignal
+    }
+
+    declare class MistralClient {
+        apiKey: string
+        endpoint: string
+        maxRetries: number
+        timeout: number
+
+        constructor(apiKey?: string, endpoint?: string, maxRetries?: number, timeout?: number);
+
+        listModels(): Promise<ListModelsResponse>;
+
+        chat(request: ChatRequest, options?: ChatRequestOptions): Promise<ChatCompletionResponse>;
+
+        chatStream(request: ChatRequest, options?: ChatRequestOptions): AsyncGenerator<ChatCompletionResponseChunk, void>;
+
+        embeddings(options: {
+            model: string;
+            input: string | string[];
+        }): Promise<EmbeddingResponse>;
+    }
+
+    export default MistralClient;
 }
-
-export interface Model {
-  id: string;
-  object: 'model';
-  created: number;
-  owned_by: string;
-  root: string | null;
-  parent: string | null;
-  permission: ModelPermission[];
-}
-
-export interface ListModelsResponse {
-  object: 'list';
-  data: Model[];
-}
-
-export interface Function {
-  name: string;
-  description: string;
-  parameters: object;
-}
-
-export interface FunctionCall {
-  name: string;
-  arguments: string;
-}
-
-export interface ToolCalls {
-  id: string;
-  function: FunctionCall;
-}
-
-export interface ResponseFormat {
-  type: 'json_object';
-}
-
-export interface TokenUsage {
-  prompt_tokens: number;
-  completion_tokens: number;
-  total_tokens: number;
-}
-
-export interface ChatCompletionResponseChoice {
-  index: number;
-  message: {
-    role: string;
-    content: string;
-    tool_calls: null | ToolCalls[];
-  };
-  finish_reason: string;
-}
-
-export interface ChatCompletionResponseChunkChoice {
-  index: number;
-  delta: {
-    role?: string;
-    content?: string;
-    tool_calls?: ToolCalls[];
-  };
-  finish_reason: string;
-}
-
-export interface ChatCompletionResponse {
-  id: string;
-  object: 'chat.completion';
-  created: number;
-  model: string;
-  choices: ChatCompletionResponseChoice[];
-  usage: TokenUsage;
-}
-
-export interface ChatCompletionResponseChunk {
-  id: string;
-  object: 'chat.completion.chunk';
-  created: number;
-  model: string;
-  choices: ChatCompletionResponseChunkChoice[];
-  usage: TokenUsage | null;
-}
-
-export interface Embedding {
-  id: string;
-  object: 'embedding';
-  embedding: number[];
-}
-
-export interface EmbeddingResponse {
-  id: string;
-  object: 'list';
-  data: Embedding[];
-  model: string;
-  usage: TokenUsage;
-}
-
-export interface Message {
-  role: string;
-  content: string | string[]
-}
-
-export interface Tool {
-  type: 'function';
-  function: Function;
-}
-
-export interface ChatRequest {
-  model: string;
-  messages: Array<Message>;
-  tools?: Array<Tool>;
-  temperature?: number;
-  maxTokens?: number;
-  topP?: number;
-  randomSeed?: number;
-  /**
-   * @deprecated use safePrompt instead
-   */
-  safeMode?: boolean;
-  safePrompt?: boolean;
-  toolChoice?: 'auto' | 'any' | 'none';
-  responseFormat?: ResponseFormat;
-}
-
-export interface ChatRequestOptions {
-  signal?: AbortSignal
-}
-
-declare class MistralClient {
-  apiKey: string
-  endpoint: string
-  maxRetries: number
-  timeout: number
-
-  constructor(apiKey?: string, endpoint?: string, maxRetries?: number, timeout?: number);
-
-  listModels(): Promise<ListModelsResponse>;
-
-  chat(request: ChatRequest, options?: ChatRequestOptions): Promise<ChatCompletionResponse>;
-
-  chatStream(request: ChatRequest, options?: ChatRequestOptions): Promise<AsyncGenerator<ChatCompletionResponseChunk, void>>;
-
-  embeddings(options: {
-    model: string;
-    input: string | string[];
-  }): Promise<EmbeddingResponse>;
-}
-
-export default MistralClient;

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -45,7 +45,7 @@ export interface ToolCalls {
 }
 
 export interface ResponseFormat {
-  type: ResponseFormats | 'json_object';
+  type: 'json_object';
 }
 
 export interface TokenUsage {
@@ -129,7 +129,7 @@ export interface ChatRequest {
    */
   safeMode?: boolean;
   safePrompt?: boolean;
-  toolChoice?: ToolChoice | 'auto' | 'any' | 'none';
+  toolChoice?: 'auto' | 'any' | 'none';
   responseFormat?: ResponseFormat;
 }
 

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -105,6 +105,7 @@ declare module '@mistralai/mistralai' {
         created: number;
         model: string;
         choices: ChatCompletionResponseChunkChoice[];
+        usage: TokenUsage | null;
     }
 
     export interface Embedding {

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -1,196 +1,177 @@
-declare module '@mistralai/mistralai' {
-    export interface ModelPermission {
-        id: string;
-        object: 'model_permission';
-        created: number;
-        allow_create_engine: boolean;
-        allow_sampling: boolean;
-        allow_logprobs: boolean;
-        allow_search_indices: boolean;
-        allow_view: boolean;
-        allow_fine_tuning: boolean;
-        organization: string;
-        group: string | null;
-        is_blocking: boolean;
-    }
-
-    export interface Model {
-        id: string;
-        object: 'model';
-        created: number;
-        owned_by: string;
-        root: string | null;
-        parent: string | null;
-        permission: ModelPermission[];
-    }
-
-    export interface ListModelsResponse {
-        object: 'list';
-        data: Model[];
-    }
-
-    export interface Function {
-        name: string;
-        description: string;
-        parameters: object;
-    }
-
-    export enum ToolType {
-        function = 'function',
-    }
-
-    export interface FunctionCall {
-        name: string;
-        arguments: string;
-    }
-
-    export interface ToolCalls {
-        id: 'null';
-        type: ToolType = ToolType.function;
-        function: FunctionCall;
-    }
-
-    export enum ResponseFormats {
-        text = 'text',
-        json_object = 'json_object',
-    }
-
-    export enum ToolChoice {
-        auto = 'auto',
-        any = 'any',
-        none = 'none',
-    }
-
-    export interface ResponseFormat {
-        type: ResponseFormats = ResponseFormats.text;
-    }
-
-    export interface TokenUsage {
-        prompt_tokens: number;
-        completion_tokens: number;
-        total_tokens: number;
-    }
-
-    export interface ChatCompletionResponseChoice {
-        index: number;
-        message: {
-            role: string;
-            content: string;
-            tool_calls: null | ToolCalls[];
-        };
-        finish_reason: string;
-    }
-
-    export interface ChatCompletionResponseChunkChoice {
-        index: number;
-        delta: {
-            role?: string;
-            content?: string;
-            tool_calls?: ToolCalls[];
-        };
-        finish_reason: string;
-    }
-
-    export interface ChatCompletionResponse {
-        id: string;
-        object: 'chat.completion';
-        created: number;
-        model: string;
-        choices: ChatCompletionResponseChoice[];
-        usage: TokenUsage;
-    }
-
-    export interface ChatCompletionResponseChunk {
-        id: string;
-        object: 'chat.completion.chunk';
-        created: number;
-        model: string;
-        choices: ChatCompletionResponseChunkChoice[];
-        usage: TokenUsage | null;
-    }
-
-    export interface Embedding {
-        id: string;
-        object: 'embedding';
-        embedding: number[];
-    }
-
-    export interface EmbeddingResponse {
-        id: string;
-        object: 'list';
-        data: Embedding[];
-        model: string;
-        usage: TokenUsage;
-    }
-
-    class MistralClient {
-        constructor(apiKey?: string, endpoint?: string);
-
-        private _request(
-            method: string,
-            path: string,
-            request: unknown
-        ): Promise<unknown>;
-
-        private _makeChatCompletionRequest(
-            model: string,
-            messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>,
-            tools?: Array<{ type: string; function: Function; }>,
-            temperature?: number,
-            maxTokens?: number,
-            topP?: number,
-            randomSeed?: number,
-            stream?: boolean,
-            /**
-             * @deprecated use safePrompt instead
-             */
-            safeMode?: boolean,
-            safePrompt?: boolean,
-            toolChoice?: ToolChoice,
-            responseFormat?: ResponseFormat
-        ): object;
-
-        listModels(): Promise<ListModelsResponse>;
-
-        chat(options: {
-            model: string;
-            messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>;
-            tools?: Array<{ type: string; function: Function; }>;
-            temperature?: number;
-            maxTokens?: number;
-            topP?: number;
-            randomSeed?: number;
-            /**
-             * @deprecated use safePrompt instead
-             */
-            safeMode?: boolean;
-            safePrompt?: boolean;
-            toolChoice?: ToolChoice;
-            responseFormat?: ResponseFormat;
-        }): Promise<ChatCompletionResponse>;
-
-        chatStream(options: {
-            model: string;
-            messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>;
-            tools?: Array<{ type: string; function: Function; }>;
-            temperature?: number;
-            maxTokens?: number;
-            topP?: number;
-            randomSeed?: number;
-            /**
-             * @deprecated use safePrompt instead
-             */
-            safeMode?: boolean;
-            safePrompt?: boolean;
-            toolChoice?: ToolChoice;
-            responseFormat?: ResponseFormat;
-        }): AsyncGenerator<ChatCompletionResponseChunk, void, unknown>;
-
-        embeddings(options: {
-            model: string;
-            input: string | string[];
-        }): Promise<EmbeddingResponse>;
-    }
-
-    export default MistralClient;
+export interface ModelPermission {
+  id: string;
+  object: 'model_permission';
+  created: number;
+  allow_create_engine: boolean;
+  allow_sampling: boolean;
+  allow_logprobs: boolean;
+  allow_search_indices: boolean;
+  allow_view: boolean;
+  allow_fine_tuning: boolean;
+  organization: string;
+  group: string | null;
+  is_blocking: boolean;
 }
+
+export interface Model {
+  id: string;
+  object: 'model';
+  created: number;
+  owned_by: string;
+  root: string | null;
+  parent: string | null;
+  permission: ModelPermission[];
+}
+
+export interface ListModelsResponse {
+  object: 'list';
+  data: Model[];
+}
+
+export interface Function {
+  name: string;
+  description: string;
+  parameters: object;
+}
+
+// TODO: this is not actually used, but would technically be a break change to remove
+export enum ToolType {
+  function = 'function',
+}
+
+export interface FunctionCall {
+  name: string;
+  arguments: string;
+}
+
+export interface ToolCalls {
+  id: string;
+  function: FunctionCall;
+}
+
+export enum ResponseFormats {
+  json_object = 'json_object',
+}
+
+export enum ToolChoice {
+  auto = 'auto',
+  any = 'any',
+  none = 'none',
+}
+
+export interface ResponseFormat {
+  type: ResponseFormats | 'json_object';
+}
+
+export interface TokenUsage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+export interface ChatCompletionResponseChoice {
+  index: number;
+  message: {
+    role: string;
+    content: string;
+    tool_calls: null | ToolCalls[];
+  };
+  finish_reason: string;
+}
+
+export interface ChatCompletionResponseChunkChoice {
+  index: number;
+  delta: {
+    role?: string;
+    content?: string;
+    tool_calls?: ToolCalls[];
+  };
+  finish_reason: string;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  object: 'chat.completion';
+  created: number;
+  model: string;
+  choices: ChatCompletionResponseChoice[];
+  usage: TokenUsage;
+}
+
+export interface ChatCompletionResponseChunk {
+  id: string;
+  object: 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: ChatCompletionResponseChunkChoice[];
+  usage: TokenUsage | null;
+}
+
+export interface Embedding {
+  id: string;
+  object: 'embedding';
+  embedding: number[];
+}
+
+export interface EmbeddingResponse {
+  id: string;
+  object: 'list';
+  data: Embedding[];
+  model: string;
+  usage: TokenUsage;
+}
+
+export interface Message {
+  role: string;
+  // TODO: this is not specified at https://docs.mistral.ai/redocusaurus/plugin-redoc-0.yaml
+  name?: string,
+  content: string | string[]
+}
+
+export interface Tool {
+  type: 'function';
+  function: Function;
+}
+
+export interface ChatRequest {
+  model: string;
+  messages: Array<Message>;
+  tools?: Array<Tool>;
+  temperature?: number;
+  maxTokens?: number;
+  topP?: number;
+  randomSeed?: number;
+  /**
+   * @deprecated use safePrompt instead
+   */
+  safeMode?: boolean;
+  safePrompt?: boolean;
+  toolChoice?: ToolChoice | 'auto' | 'any' | 'none';
+  responseFormat?: ResponseFormat;
+}
+
+export interface ChatRequestOptions {
+  signal?: AbortSignal
+}
+
+declare class MistralClient {
+  apiKey: string
+  endpoint: string
+  maxRetries: number
+  timeout: number
+
+  constructor(apiKey?: string, endpoint?: string, maxRetries?: number, timeout?: number);
+
+  listModels(): Promise<ListModelsResponse>;
+
+  chat(request: ChatRequest, options?: ChatRequestOptions): Promise<ChatCompletionResponse>;
+
+  chatStream(request: ChatRequest, options?: ChatRequestOptions): Promise<AsyncGenerator<ChatCompletionResponseChunk, void>>;
+
+  embeddings(options: {
+    model: string;
+    input: string | string[];
+  }): Promise<EmbeddingResponse>;
+}
+
+export default MistralClient;

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -138,7 +138,7 @@ declare module '@mistralai/mistralai' {
         signal?: AbortSignal
     }
 
-    declare class MistralClient {
+    class MistralClient {
         apiKey: string
         endpoint: string
         maxRetries: number

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -76,6 +76,7 @@ declare module '@mistralai/mistralai' {
         message: {
             role: string;
             content: string;
+            tool_calls: null | ToolCalls[];
         };
         finish_reason: string;
     }
@@ -134,7 +135,7 @@ declare module '@mistralai/mistralai' {
         private _makeChatCompletionRequest(
             model: string,
             messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>,
-            tools?: Array<{ type: string; function:Function; }>, 
+            tools?: Array<{ type: string; function: Function; }>,
             temperature?: number,
             maxTokens?: number,
             topP?: number,
@@ -154,7 +155,7 @@ declare module '@mistralai/mistralai' {
         chat(options: {
             model: string;
             messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>;
-            tools?: Array<{ type: string; function:Function; }>; 
+            tools?: Array<{ type: string; function: Function; }>;
             temperature?: number;
             maxTokens?: number;
             topP?: number;
@@ -165,13 +166,13 @@ declare module '@mistralai/mistralai' {
             safeMode?: boolean;
             safePrompt?: boolean;
             toolChoice?: ToolChoice;
-            responseFormat?: ResponseFormat; 
+            responseFormat?: ResponseFormat;
         }): Promise<ChatCompletionResponse>;
 
         chatStream(options: {
             model: string;
             messages: Array<{ role: string; name?: string, content: string | string[], tool_calls?: ToolCalls[]; }>;
-            tools?: Array<{ type: string; function:Function; }>;
+            tools?: Array<{ type: string; function: Function; }>;
             temperature?: number;
             maxTokens?: number;
             topP?: number;


### PR DESCRIPTION
This should make the typescript definitions at least useable. Currently they seem to be quite broken (per #69, #67 )  

Closes #54 
Closes #47 
Closes #69 
Closes #67 
Closes #62 

- Adds examples/typescript and build in CI step
- Fixes definitions (trying to set defaults, chatStream returning wrong type)
- Add signal (per #68) to typescript definitions 
- Fix interfaces (non-exhaustively) per: https://docs.mistral.ai/redocusaurus/plugin-redoc-0.yaml
