### PR TITLE
Turns anonymous functions into class methods

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -383,7 +383,7 @@ class MistralClient {
    *                               default timeout signal
    * @return {Promise<Object>}
    */
-  async * chatStream(
+  async* chatStream(
     {
       model,
       messages,
@@ -525,7 +525,7 @@ class MistralClient {
    *                               default timeout signal
    * @return {Promise<Object>}
    */
-  async * completionStream(
+  async* completionStream(
     {model, prompt, suffix, temperature, maxTokens, topP, randomSeed, stop},
     {signal} = {},
   ) {

--- a/src/client.js
+++ b/src/client.js
@@ -107,7 +107,7 @@ class MistralClient {
    * @param {*} formData
    * @return {Promise<*>}
    */
-  _request = async function(method, path, request, signal, formData = null) {
+  async _request(method, path, request, signal, formData = null) {
     const url = `${this.endpoint}/${path}`;
     const options = {
       method: method,
@@ -207,7 +207,7 @@ class MistralClient {
    * @param {*} responseFormat
    * @return {Promise<Object>}
    */
-  _makeChatCompletionRequest = function(
+  _makeChatCompletionRequest(
     model,
     messages,
     tools,
@@ -253,7 +253,7 @@ class MistralClient {
    * @param {*} stream
    * @return {Promise<Object>}
    */
-  _makeCompletionRequest = function(
+  _makeCompletionRequest(
     model,
     prompt,
     suffix,
@@ -285,7 +285,7 @@ class MistralClient {
    * Returns a list of the available models
    * @return {Promise<Object>}
    */
-  listModels = async function() {
+  async listModels() {
     const response = await this._request('get', 'v1/models');
     return response;
   };
@@ -317,7 +317,7 @@ class MistralClient {
    *                               default timeout signal
    * @return {Promise<Object>}
    */
-  chat = async function(
+  async chat(
     {
       model,
       messages,
@@ -383,7 +383,7 @@ class MistralClient {
    *                               default timeout signal
    * @return {Promise<Object>}
    */
-  chatStream = async function* (
+  async * chatStream(
     {
       model,
       messages,
@@ -446,7 +446,7 @@ class MistralClient {
    * e.g. ['What is the best French cheese?']
    * @return {Promise<Object>}
    */
-  embeddings = async function({model, input}) {
+  async embeddings({model, input}) {
     const request = {
       model: model,
       input: input,
@@ -478,7 +478,7 @@ class MistralClient {
    *                               default timeout signal
    * @return {Promise<Object>}
    */
-  completion = async function(
+  async completion(
     {model, prompt, suffix, temperature, maxTokens, topP, randomSeed, stop},
     {signal} = {},
   ) {
@@ -525,7 +525,7 @@ class MistralClient {
    *                               default timeout signal
    * @return {Promise<Object>}
    */
-  completionStream = async function* (
+  async * completionStream(
     {model, prompt, suffix, temperature, maxTokens, topP, randomSeed, stop},
     {signal} = {},
   ) {


### PR DESCRIPTION
Currently most methods on the `MistralClient` are implemented as anonymous functions/class fields (`myMethod = function() {...}`). This makes it hard to inherit, overwrite, and monkeypatch these methods.

Example:
```js
import * as MistralAI from "@mistralai/mistralai";

const originalChat = MistralAI.prototype.chat;
MistralAI.prototype.chat = function(...) {...};
// originalChat is undefined
```

This PR changes all of these functions to real class methods, which allows for easier monkeypatching etc.

Closes #58 